### PR TITLE
Add README service management instructions and MIT license

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,10 +1,10 @@
-# Alby-Hub
+# Example configuration for Alby Hub
 BASE_URL=https://albyhub.f418.ch
 FRONTEND_URL=https://albyhub.f418.ch
 PORT=8080
 WORK_DIR=/data/albyhub
 JWT_SECRET=$(openssl rand -hex 32)
 
-# Optional: E-Mail für Let’s Encrypt
+# Optional: email address for Let's Encrypt
 CADDY_ACME_EMAIL=info@f418.ch
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AlbyHub Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# AlbyHub Docker Setup
+
+This repository contains a minimal Docker Compose configuration for running [Alby Hub](https://github.com/getAlby/hub) behind a Caddy reverse proxy.
+
+## Prerequisites
+
+- Docker and Docker Compose installed on your host machine
+- A domain name you control for HTTPS
+
+## Setup
+
+1. Clone this repository.
+2. Copy `.env-example` to `.env` and adjust the values as needed. The most important settings are:
+   - `BASE_URL` / `FRONTEND_URL` – the public URL of your Alby Hub instance.
+   - `PORT` – the internal port used by the application (default: `8080`).
+   - `JWT_SECRET` – a random secret used for authentication.
+   - `CADDY_ACME_EMAIL` – email address for Let's Encrypt certificates.
+3. Start the services with `docker compose up -d`.
+4. Caddy will automatically obtain HTTPS certificates and forward traffic to the Alby Hub container.
+
+Application data is stored in the `albyhub-data` directory. Caddy stores its configuration and certificates in `caddy/data` and `caddy/config`.
+## Managing Services
+
+Start the containers in the background with:
+
+```bash
+docker compose up -d
+```
+
+Stop and remove them:
+
+```bash
+docker compose down
+```
+
+To stop without removing containers, use:
+
+```bash
+docker compose stop
+```
+
+Monitor running containers:
+
+```bash
+docker compose ps
+```
+
+Follow logs in real time:
+
+```bash
+docker compose logs -f
+```
+
+
+## File Overview
+
+- `docker-compose.yml` – defines the Alby Hub and Caddy services.
+- `caddy/Caddyfile` – Caddy configuration for the reverse proxy.
+- `.env-example` – environment variables example file.
+

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,7 +1,7 @@
 albyhub.f418.ch {
     reverse_proxy albyhub:8080
 
-    # Kompression & kleine Sicherheits­header
+    # Compression and basic security headers
     encode gzip
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file: .env
     volumes:
       - ./albyhub-data:/data
-    expose:             # nur intern – kein publiker Port nötig
+    expose:             # internal only - no public port needed
       - "8080"
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- add new "Managing Services" section to README with Docker Compose start, stop and monitoring commands
- remove obsolete license section
- include MIT License text
- translate remaining German comments in example files to English

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687202a57ca48333a32bc4d04da60d11